### PR TITLE
Fix CSV downloads for runningcatalog_detail, transient_detail.

### DIFF
--- a/banana/templates/banana/runningcatalog_detail.csv
+++ b/banana/templates/banana/runningcatalog_detail.csv
@@ -1,3 +1,3 @@
 #id, taustart_ts, tau_time, freq_central, f_int, fint_err
-{% for point in lightcurve %}{{ point.id }}, "{{ point.image.taustart_ts|date:"c" }}", {{ point.image.tau_time }}, {{ point.image.band.freq_central }}, {{ point.f_int }}, {{ point.f_int_err }}
+{% for point in object_list %}{{ point.id }}, "{{ point.image.taustart_ts|date:"c" }}", {{ point.image.tau_time }}, {{ point.image.band.freq_central }}, {{ point.f_int }}, {{ point.f_int_err }}
 {% endfor %}

--- a/banana/templates/banana/transient_detail.csv
+++ b/banana/templates/banana/transient_detail.csv
@@ -1,4 +1,4 @@
 #band, taustart_ts, f_int, f_int_err, tau_time
-{% for point in paginator.object_list %}"{{ point.image.band }}", "{{ point.image.taustart_ts|date:"c" }}", {{ point.f_int }}, {{ point.f_int_err }}, {{ point.image.tau_time }}
+{% for point in object_list %}"{{ point.image.band }}", "{{ point.image.taustart_ts|date:"c" }}", {{ point.f_int }}, {{ point.f_int_err }}, {{ point.image.tau_time }}
 {% endfor %}
 


### PR DESCRIPTION
I just fixed these up to match the html views. Exactly
what context object contains the data seems to vary from view
to view, this could probably use a little reviewing.
(And unit tests, as discussed.)
