### PR TITLE
Change transient_detail header numbering to relate to dataset.

### DIFF
--- a/banana/models.py
+++ b/banana/models.py
@@ -555,6 +555,22 @@ class Transient(models.Model):
         return Extractedsource.objects.using(self._state.db).\
             filter(asocxtrsources__in=assocs).prefetch_related(*related)
 
+    def index_in_dataset(self):
+        #Memoize this, since it's not going to change
+        # (unless a transient is deleted?)
+        if not hasattr(self, '_index_in_dataset'):
+            qs = Transient.objects.using(self._state.db).\
+                filter(runcat__dataset=self.runcat.dataset,
+                       ).\
+                order_by("id")
+            l = list(qs.values_list('id', flat=True))
+            self._index_in_dataset = l.index(self.id)
+        return self._index_in_dataset
+
+    def number_in_dataset(self):
+        num = Transient.objects.using(self._state.db).\
+            filter(runcat__dataset=self.runcat.dataset).count()
+        return num
 
     def get_next_by_id_offset(self, offset):
         """

--- a/banana/templates/banana/transient_detail.html
+++ b/banana/templates/banana/transient_detail.html
@@ -20,7 +20,7 @@
 
 <div class="row-fluid">
     <div class="span5">
-        <h2>Transient #{{ object.id }}</h2>
+        <h2>Transient {{object.index_in_dataset|add:1 }} of {{object.number_in_dataset}} (ID {{ object.id }})</h2>
 
         <div class="pagination">
             <ul>


### PR DESCRIPTION
Database wide id numbers can be somewhat confusing.
