### PR TITLE
Revert transient_detail headline to Transient ID #.

### DIFF
--- a/banana/templates/banana/transient_detail.html
+++ b/banana/templates/banana/transient_detail.html
@@ -21,7 +21,8 @@
 
 <div class="row-fluid">
     <div class="span5">
-        <h2>Transient {{object.index_in_dataset|add:1 }} of {{object.number_in_dataset}} (ID {{ object.id }})</h2>
+        <h2>Transient #{{ object.id }}</h2>
+        <h5>({{object.index_in_dataset|add:1 }} of {{object.number_in_dataset}} in Dataset {{object.runcat.dataset_id}})</h5>
 
         <div class="pagination">
             <ul>


### PR DESCRIPTION
Keep 'x of y' as a subheader.

NB this may need a manual merge with https://github.com/transientskp/banana/pull/23 but that should be pretty trivial.
