### PR TITLE
mark transient lightcurve sources in image

### DIFF
--- a/banana/models.py
+++ b/banana/models.py
@@ -348,6 +348,19 @@ class Image(models.Model):
             raise ObjectDoesNotExist
         return Image.objects.using(self._state.db).get(id=id)
 
+    def transient_sources(self):
+        """
+        returns a list of extracted sources that are part of a transient
+        lightcurve
+        """
+        q = """
+        SELECT e.*
+        FROM extractedsource AS e, image AS i, assocxtrsource AS a,
+          runningcatalog as r
+        WHERE a.runcat = r.id AND a.xtrsrc = e.id AND e.image = i.id AND i.id=%s
+        """
+        return Extractedsource.objects.raw(q, [self.id]).using(self._state.db)
+
 
 class Node(models.Model):
     id = models.IntegerField(primary_key=True)
@@ -610,9 +623,9 @@ class Transient(models.Model):
 
     def get_next_by_id(self):
         return self.get_next_by_id_offset(1)
+
     def get_prev_by_id(self):
         return self.get_next_by_id_offset(-1)
-
 
 
 class Version(models.Model):

--- a/banana/templates/banana/bigimage_detail.html
+++ b/banana/templates/banana/bigimage_detail.html
@@ -19,6 +19,11 @@
 
 <img src="{% url 'image_plot' db_name image.id %}?size={{ image_size }}" class="map" usemap="#simple">
 
+<b>yellow:</b> blind fit
+<b>lightgreen:</b> forced fit
+<b>cyan:</b> manual monitored
+<b>blue:</b> transient
+
 <map name="simple">
     {% for id, x, y, size in sources %}
         <area shape="circle" id="{{ id }}" coords="{{ x }}, {{ y }}, {{ size }}" href="{% url 'extractedsource' db_name id %}" alt="{{ id }}" title="{{ id }}" >

--- a/banana/tests.py
+++ b/banana/tests.py
@@ -62,7 +62,6 @@ class ViewTest(TestCase):
 
     def test_list_views_with_dataset(self):
         for list_view in self.list_views:
-            print list_view
             response = self.client.get(reverse(list_view,
                                                kwargs={'db': test_db}) +
                                        "?dataset=1")

--- a/banana/views/images.py
+++ b/banana/views/images.py
@@ -15,6 +15,7 @@ class ImagePlot(MultiDbMixin, DetailView):
     def get_context_data(self, **kwargs):
         context = super(ImagePlot, self).get_context_data(**kwargs)
         context['sources'] = self.object.extractedsources.all()
+        context['transients'] = self.object.transient_sources()
         try:
             context['size'] = int(self.request.GET.get('size', 5))
         except ValueError:
@@ -26,7 +27,8 @@ class ImagePlot(MultiDbMixin, DetailView):
         response = HttpResponse(mimetype="image/png")
         if context['hdu']:
             canvas = banana.image.image_plot(context['hdu'], context['size'],
-                                             context['sources'])
+                                             context['sources'],
+                                             context['transients'])
             canvas.print_figure(response, format='png', bbox_inches='tight',
                                 pad_inches=0, dpi=100)
         return response


### PR DESCRIPTION
this implements feature request #4613

https://support.astron.nl/lofar_issuetracker/issues/4613

btw, for me this results in that almost all sources have a blue circle around it, because everything is a transient.
