### PR TITLE
Various formatting fixes related to issues #69, #83 and #84

### DIFF
--- a/banana/templates/banana/extractedsource_detail.html
+++ b/banana/templates/banana/extractedsource_detail.html
@@ -29,13 +29,13 @@
             <dt>Position (decimal)</dt>
             <dd>({{ extractedsource.ra|stringformat:".3f" }}&deg;, {{ extractedsource.decl|stringformat:".3f" }}&deg;) &pm; ({{ extractedsource.ra_err|deg2asec|stringformat:".3f" }}&Prime;, {{ extractedsource.decl_err|deg2asec|stringformat:".3f" }}&Prime;)</dd>
 
-            <dt>Position (Sexagesimal)</dt>
+            <dt>Position (sexagesimal)</dt>
             <dd>{% sexagesimal extractedsource.ra extractedsource.decl extractedsource.ra_err extractedsource.decl_err %}</dd>
 
             <dt>Signal to noise</dt>
             <dd>{{ extractedsource.det_sigma|stringformat:".3f" }}</dd>
 
-            <dt>Peak flux (Jy)</dt>
+            <dt>Peak flux (Jy beam<sup>-1</sup>)</dt>
             <dd>{{ extractedsource.f_peak|scientific }} &pm; {{ extractedsource.f_peak_err|scientific }}</dd>
 
             <dt>Integrated flux (Jy)</dt>
@@ -56,10 +56,10 @@
             {% endfor %}
             </dd>
 
-            <dt>Semi-major axis (arcsec)</dt>
+            <dt style='white-space: normal'>Semi-major axis (arcsec)</dt>
             <dd>{{ extractedsource.semimajor|scientific }}</dd>
 
-            <dt>Semi-minor axis (arcsec)</dt>
+            <dt style='white-space: normal'>Semi-minor axis (arcsec)</dt>
             <dd>{{ extractedsource.semiminor|scientific }}</dd>
 
             <dt>Position angle (deg)</dt>

--- a/banana/templates/banana/monitor_detail.html
+++ b/banana/templates/banana/monitor_detail.html
@@ -26,16 +26,16 @@
                     <dt>Dataset</dt>
                     <dd><a href="{% url 'dataset' db_name object.dataset.id %}">{{ object.dataset }}</a></dd>
 
-                    <dt>Ra(°)</dt>
+                    <dt>RA (°)</dt>
                     <dd>{{ object.ra|stringformat:".3f" }}</dd>
 
-                    <dt>Dec(°)</dt>
+                    <dt>Dec (°)</dt>
                     <dd>{{ object.decl|stringformat:".3f" }}</dd>
 
-                    <dt>Ra(h:m:s)</dt>
+                    <dt>RA (hh:mm:ss.s)</dt>
                     <dd>{{object.ra|format_angle:"time"}}</dd>
 
-                    <dt>Dec(d:m:s)</dt>
+                    <dt>Dec(dd:mm:ss.s)</dt>
                     <dd>{{object.decl|format_angle:"dms"}}</dd>
 
                     <dt>Running catalog</dt>

--- a/banana/templates/banana/monitor_list.html
+++ b/banana/templates/banana/monitor_list.html
@@ -38,10 +38,10 @@
                         <tr>
                             {% tableheader 'id' %}
                             {% tableheader 'dataset' %}
-                            {% tableheader 'ra' 'Ra(°)' %}
-                            {% tableheader 'decl' 'Dec(°)' %}
-                            {% tableheader 'ra' 'Ra(h:m:s)' %}
-                            {% tableheader 'decl' 'Dec(d:m:s)' %}
+                            {% tableheader 'ra' 'RA (°)' %}
+                            {% tableheader 'decl' 'Dec (°)' %}
+                            {% tableheader 'ra' 'RA (hh:mm:ss.s)' %}
+                            {% tableheader 'decl' 'Dec (dd:mm:ss.s)' %}
                             {% tableheader 'runcat' %}
                             {% tableheader 'name'  %}
 

--- a/banana/templates/banana/newsource_list.html
+++ b/banana/templates/banana/newsource_list.html
@@ -39,7 +39,7 @@
                         <tr>
                             {% tableheader 'id' 'ID' %}
                             {% tableheader 'runcat__wm_ra' 'Pos (°)' %}
-                            {% tableheader 'runcat__wm_ra' 'Pos (h:m:s,d:m:s)' %}
+                            {% tableheader 'runcat__wm_ra' 'Pos (hh:mm:ss.s, dd:mm:ss.s)' %}
                             {% tableheader 'trigger_xtrsrc__image__taustart_ts' 'Start date' %}
                             {% tableheader 'runcat__datapoints' '# of points' %}
                             {% tableheader 'runcat' 'Run. cat. #' %}

--- a/banana/templates/banana/runningcatalog_detail.html
+++ b/banana/templates/banana/runningcatalog_detail.html
@@ -65,10 +65,10 @@
                                 ({{ object.ra_err|deg2asec|stringformat:".3f" }}″,
                                 {{ object.wm_uncertainty_ns|deg2asec|stringformat:".3f" }}″)</dd>
 
-                            <dt>Ra(h:m:s)</dt>
+                            <dt>RA (hh:mm:ss.s)</dt>
                             <dd>{{object.wm_ra|format_angle:"time"}}</dd>
 
-                            <dt>Dec(d:m:s)</dt>
+                            <dt>Dec (dd:mm:ss.s)</dt>
                             <dd>{{object.wm_decl|format_angle:"dms"}}</dd>
 
                             <dt>New source</dt>
@@ -102,13 +102,13 @@
                             <dt>Dataset</dt>
                             <dd><a href="{% url 'dataset' db_name object.dataset.id %}">{{ object.dataset }}</a></dd>
 
-                            <dt>Max flux</dt>
+                            <dt>Max int. flux (Jy)</dt>
                             <dd>{{ object.lightcurve_max|stringformat:".3f" }}</dd>
 
-                            <dt>Mean flux</dt>
+                            <dt>Mean int. flux (Jy)</dt>
                             <dd>{{ object.lightcurve_avg|stringformat:".3f" }}</dd>
 
-                            <dt>Median flux</dt>
+                            <dt>Median int. flux (Jy)</dt>
                             <dd>{{ object.lightcurve_median|stringformat:".3f" }}</dd>
                         </dl>
                     </div>
@@ -145,8 +145,8 @@
                     {% tableheader 'xtrsrc__image__band__freq_central' 'Frequency (Hz)' %}
                     {% tableheader 'xtrsrc__f_int' 'Int. flux (Jy)' %}
                     {% tableheader 'xtrsrc__f_int_err' 'Int. flux err (Jy)' %}
-                    {% tableheader 'xtrsrc__f_peak' 'Peak flux (Jy)' %}
-                    {% tableheader 'xtrsrc__f_peak_err' 'Peak flux err (Jy)' %}
+                    {% tableheader 'xtrsrc__f_peak' 'Peak flux (Jy beam<sup>-1</sup>)' %}
+                    {% tableheader 'xtrsrc__f_peak_err' 'Peak flux err (Jy beam<sup>-1</sup>)' %}
                     {% tableheader 'xtrsrc__extract_type' 'Extract type' %}
                     {% tableheader 'xtrsrc__image' 'Image ID' %}
                     {% tableheader 'v_int' 'Vν' %}

--- a/banana/templates/banana/runningcatalog_filter.html
+++ b/banana/templates/banana/runningcatalog_filter.html
@@ -36,7 +36,7 @@
                     <div class="form-group col-md-4">
                         <div class="row">
                             <div class="col-md-4">
-                                <label for="id_wm_ra" class="col-xs-1 control-label">Ra(°):</label>
+                                <label for="id_wm_ra" class="col-xs-1 control-label">RA(°):</label>
                             </div>
                             <div class="col-md-4">
                                 <input class="form-control" id="id_wm_ra_0" name="wm_ra_0" type="text" {% if filter.form.wm_ra.value.0 %}value="{{ filter.form.wm_ra.value.0 }}"{% endif %} placeholder="min"/>
@@ -154,14 +154,14 @@
                         <thead>
                         <tr>
                             {% tableheader 'id' '#' %}
-                            {% tableheader 'wm_ra' 'Ra(°)' %}
-                            {% tableheader 'wm_decl' 'Dec(°)' %}
-                            <th>Ra Error(″)</th>
-                            <th>Decl Error(″)</th>
-                            {% tableheader 'wm_ra' 'Ra(h:m:s)' %}
-                            {% tableheader 'wm_decl' 'Dec(d:m:s)' %}
+                            {% tableheader 'wm_ra' 'RA (°)' %}
+                            {% tableheader 'wm_decl' 'Dec (°)' %}
+                            <th>RA Error (″)</th>
+                            <th>Dec Error (″)</th>
+                            {% tableheader 'wm_ra' 'RA (hh:mm:ss.s)' %}
+                            {% tableheader 'wm_decl' 'Dec (dd:mm:ss.s)' %}
                             {% tableheader 'datapoints' '# points' %}
-                            {% tableheader 'newsource' 'new source' %}
+                            {% tableheader 'newsource' 'New source' %}
                             {% tableheader 'sigma_rms_min' 'Σ<sub>RMS<sub>min</sub></sub>' %}
                             {% tableheader 'sigma_rms_max' 'Σ<sub>RMS<sub>max</sub></sub>' %}
                             {% tableheader 'lightcurve_avg' 'flux<sub>mean</sub> (Jy)' %}

--- a/banana/templates/tags/sexagesimal.html
+++ b/banana/templates/tags/sexagesimal.html
@@ -6,4 +6,4 @@ See units.py for context.
 
 {% endcomment %}
 {% load units %}
-({{ ra|format_angle }}, {{ decl|format_angle:"dms" }})&pm;({{ ra_err|deg2asec|format_ra_error|stringformat:".3f" }}&Prime;, {{ decl_err|deg2asec|stringformat:".3f" }}&Prime;)
+({{ ra|format_angle }}, {{ decl|format_angle:"dms" }}) &pm; ({{ ra_err|deg2asec|format_ra_error|stringformat:".3f" }}<sup>s</sup>, {{ decl_err|deg2asec|stringformat:"06.3f" }}&Prime;)

--- a/banana/templatetags/units.py
+++ b/banana/templatetags/units.py
@@ -76,10 +76,10 @@ def format_angle(value, format_type="time"):
     """
     if format_type == "time":
         h, m, s = deg_to_hms(float(value))
-        result = "%d<sup>h</sup>%d<sup>m</sup>%.1f<sup>s</sup>" % (h, m, s)
+        result = "%02d<sup>h</sup> %02d<sup>m</sup> %02.1f<sup>s</sup>" % (h, m, s)
     if format_type == "dms":
         sign, d, m, s = deg_to_dms(float(value))
-        result = "%s%d&deg; %d&prime; %.1f&Prime;" % (sign, d, m, s)
+        result = "%s%02d&deg; %02d&prime; %04.1f&Prime;" % (sign, d, m, s)
     return mark_safe(result)
 
 


### PR DESCRIPTION
Provides fixes for issues #69, #83 and #84.

Full changes:

* (Sexagesimal) -> (sexagesimal)
* Jy beam^-1 added where needed
* Made sure '(arcsec)' is not truncated on extracted source detail page
* Ra -> RA
* Add space between variable and unit to make consistent
* (h/d:m :s) -> (hh/dd:mm:ss.s)
* Stated that max, mean and median flux values are integrated flux values
* Added whitespace around sexagesimal +/-
* Zero padded sexagesimal
* Sexagesimal RA error unit corrected (" -> s)